### PR TITLE
Feature/patterns with todos working

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,11 @@ services:
       - microservices-net
     volumes:
       - redis-data:/data
+    command: redis-server --appendonly yes --appendfsync everysec --save 60 1
     restart: unless-stopped
-
+    environment:
+      - REDIS_MAXMEMORY=256mb
+      - REDIS_MAXMEMORY_POLICY=allkeys-lru
   # Distributed tracing
   zipkin:
     image: openzipkin/zipkin

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -9,36 +9,11 @@ RUN npm run build
 # production stage
 FROM nginx:1.13.12-alpine as production-stage
 
-# Install gettext for envsubst
-RUN apk add --no-cache gettext
-
 # Copy built application
 COPY --from=build-stage /app/dist /usr/share/nginx/html
 
-# Copy nginx template
-COPY nginx.conf.template /etc/nginx/nginx.conf.template
-
-# Create startup script directly in Dockerfile
-RUN cat > /start.sh << 'EOF'
-#!/bin/sh
-set -e
-
-# Replace environment variables in nginx.conf.template
-envsubst '${AUTH_API_URL} ${TODOS_API_URL} ${USERS_API_URL}' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf
-
-# Create config.js with the API URLs for client-side access
-cat > /usr/share/nginx/html/config.js << 'INNER_EOF'
-window.CONFIG = {
-  AUTH_API_URL: '${AUTH_API_URL}',
-  TODOS_API_URL: '${TODOS_API_URL}',
-  USERS_API_URL: '${USERS_API_URL}'
-};
-INNER_EOF
-
-# Start nginx
-exec nginx -g 'daemon off;'
-EOF
-RUN chmod +x /start.sh
+# ✅ USAR archivo estático en lugar de template
+COPY nginx.conf /etc/nginx/nginx.conf
 
 EXPOSE 80
-CMD ["/start.sh"]
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/src/components/Todos.vue
+++ b/frontend/src/components/Todos.vue
@@ -127,16 +127,14 @@ export default {
       if (this.newTask) {
         this.isProcessing = true;
         this.errorMessage = "";
+        const payload = { content: this.newTask };
 
-        var task = {
-          content: this.newTask,
-        };
-
-        this.$http.post("/todos", task).then(
+        this.$http.post("/todos", payload).then(
           (response) => {
             this.newTask = "";
             this.isProcessing = false;
-            this.tasks.push(task);
+            // ✅ Usar el objeto devuelto (tiene id correcto)
+            this.tasks.push(response.body);
           },
           (error) => {
             this.isProcessing = false;

--- a/frontend/start.sh
+++ b/frontend/start.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Replace environment variables in nginx.conf.template
 envsubst '${AUTH_API_URL} ${TODOS_API_URL} ${USERS_API_URL}' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf

--- a/todos-api/cache-aside-service.js
+++ b/todos-api/cache-aside-service.js
@@ -1,75 +1,96 @@
 const redis = require("redis");
+const { promisify } = require("util");
 
 class CacheAsideService {
   constructor(redisClient, defaultTTL = 300) {
     this.redis = redisClient;
     this.defaultTTL = defaultTTL;
+
+    // Promisify (node-redis v2.x)
+    this._getAsync = promisify(this.redis.get).bind(this.redis);
+    this._setAsync = promisify(this.redis.set).bind(this.redis);
+    this._setexAsync = promisify(this.redis.setex).bind(this.redis);
+    this._delAsync = promisify(this.redis.del).bind(this.redis);
   }
 
   async set(key, data, ttl = this.defaultTTL) {
     try {
-      if (!data || !data.items || typeof data.lastInsertedID !== 'number') {
-        console.error(`Invalid data structure for ${key}`);
+      if (!this._isValidStructure(data)) {
+        console.error(`[CacheAside:set] Invalid data structure for ${key}`, data);
         return;
       }
-      
-      await this.redis.setex(key, ttl, JSON.stringify(data));
-      console.log(`Cache actualizado para ${key} con ${Object.keys(data.items).length} items`);
-    } catch (error) {
-      console.error(`Error actualizando cache para ${key}:`, error);
-      throw error;
+      const dataString = JSON.stringify(data);
+      if (ttl > 0) {
+        await this._setexAsync(key, ttl, dataString);
+        console.log(`Cache actualizado para ${key} con TTL ${ttl}s`);
+      } else {
+        await this._setAsync(key, dataString);
+        console.log(`Cache actualizado para ${key} sin expiración`);
+      }
+    } catch (e) {
+      console.error(`Error actualizando cache para ${key}:`, e);
+      throw e;
     }
   }
 
-  // Patrón Cache-Aside clásico
   async get(key, fetchFunction, ttl = this.defaultTTL) {
     try {
-      // 1. Intentar obtener del caché
-      const cached = await this.redis.get(key);
-      if (cached) {
+      let raw = null;
+      try {
+        raw = await this._getAsync(key);
+      } catch (gErr) {
+        console.warn(`[CacheAside:get] Error ejecutando GET para ${key}`, gErr.message);
+      }
+
+      if (raw !== null && raw !== undefined) {
         console.log(`Cache HIT para ${key}`);
-        
+        console.log(`[RAW ${key}] ${raw}`);
         try {
-          const parsedData = JSON.parse(cached);
-          
-          // Validación simple pero efectiva
-          if (parsedData && parsedData.items && typeof parsedData.lastInsertedID === 'number') {
-            return parsedData;
-          } else {
-            console.warn(`Invalid cached data for ${key} - regenerating`);
-            await this.redis.del(key);
-          }
-        } catch (parseError) {
-          console.warn(`Parse error for ${key} - deleting corrupted cache`);
-          await this.redis.del(key);
+          const parsed = JSON.parse(raw);
+            if (this._isValidStructure(parsed)) {
+              return parsed;
+            } else {
+              console.warn(`[CacheAside:get] Invalid structure in cache for ${key}, deleting`);
+              await this._delAsync(key);
+            }
+        } catch (parseErr) {
+          console.warn(`[CacheAside:get] JSON parse error for ${key}, deleting`, parseErr.message);
+          await this._delAsync(key);
         }
+      } else {
+        console.log(`Cache MISS para ${key}`);
       }
 
-      console.log(`Cache MISS para ${key}`);
-      
-      // 2. Ejecutar función para obtener datos frescos
-      const data = await fetchFunction();
-
-      // 3. Validar y guardar en caché
-      if (data && data.items && typeof data.lastInsertedID === 'number') {
-        await this.redis.setex(key, ttl, JSON.stringify(data));
+      // Regenerar desde origen (default/fuente)
+      const fresh = await fetchFunction();
+      if (this._isValidStructure(fresh)) {
+        await this.set(key, fresh, ttl);
+      } else {
+        console.error(`[CacheAside:get] fetchFunction devolvió estructura inválida para ${key}`, fresh);
       }
-
-      return data;
-    } catch (error) {
-      console.error("Error en cache-aside:", error);
-      // Fallback: ejecutar función directamente
+      return fresh;
+    } catch (e) {
+      console.error(`[CacheAside:get] Error general para ${key}:`, e);
       return await fetchFunction();
     }
   }
 
   async invalidate(key) {
     try {
-      await this.redis.del(key);
+      await this._delAsync(key);
       console.log(`Cache invalidado para ${key}`);
-    } catch (error) {
-      console.error("Error invalidando caché:", error);
+    } catch (e) {
+      console.error(`Error invalidando cache ${key}:`, e);
     }
+  }
+
+  _isValidStructure(obj) {
+    return obj &&
+      typeof obj === 'object' &&
+      obj.items &&
+      typeof obj.items === 'object' &&
+      typeof obj.lastInsertedID === 'number' &&
+      obj.lastInsertedID > 0;
   }
 }
 

--- a/todos-api/cache-aside-service.js
+++ b/todos-api/cache-aside-service.js
@@ -6,6 +6,21 @@ class CacheAsideService {
     this.defaultTTL = defaultTTL;
   }
 
+  async set(key, data, ttl = this.defaultTTL) {
+    try {
+      if (!data || !data.items || typeof data.lastInsertedID !== 'number') {
+        console.error(`Invalid data structure for ${key}`);
+        return;
+      }
+      
+      await this.redis.setex(key, ttl, JSON.stringify(data));
+      console.log(`Cache actualizado para ${key} con ${Object.keys(data.items).length} items`);
+    } catch (error) {
+      console.error(`Error actualizando cache para ${key}:`, error);
+      throw error;
+    }
+  }
+
   // Patrón Cache-Aside clásico
   async get(key, fetchFunction, ttl = this.defaultTTL) {
     try {
@@ -13,45 +28,47 @@ class CacheAsideService {
       const cached = await this.redis.get(key);
       if (cached) {
         console.log(`Cache HIT para ${key}`);
-        return JSON.parse(cached);
+        
+        try {
+          const parsedData = JSON.parse(cached);
+          
+          // Validación simple pero efectiva
+          if (parsedData && parsedData.items && typeof parsedData.lastInsertedID === 'number') {
+            return parsedData;
+          } else {
+            console.warn(`Invalid cached data for ${key} - regenerating`);
+            await this.redis.del(key);
+          }
+        } catch (parseError) {
+          console.warn(`Parse error for ${key} - deleting corrupted cache`);
+          await this.redis.del(key);
+        }
       }
 
       console.log(`Cache MISS para ${key}`);
-
-      // 2. Cache miss - ejecutar función de obtención
+      
+      // 2. Ejecutar función para obtener datos frescos
       const data = await fetchFunction();
 
-      // 3. Guardar en caché para próximas consultas
-      await this.redis.setex(key, ttl, JSON.stringify(data));
+      // 3. Validar y guardar en caché
+      if (data && data.items && typeof data.lastInsertedID === 'number') {
+        await this.redis.setex(key, ttl, JSON.stringify(data));
+      }
 
       return data;
     } catch (error) {
       console.error("Error en cache-aside:", error);
-      // En caso de error de Redis, ejecutar función directamente
+      // Fallback: ejecutar función directamente
       return await fetchFunction();
     }
   }
 
-  // Invalidar caché cuando hay actualizaciones
   async invalidate(key) {
     try {
       await this.redis.del(key);
       console.log(`Cache invalidado para ${key}`);
     } catch (error) {
       console.error("Error invalidando caché:", error);
-    }
-  }
-
-  // Invalidar múltiples claves con patrón
-  async invalidatePattern(pattern) {
-    try {
-      const keys = await this.redis.keys(pattern);
-      if (keys.length > 0) {
-        await this.redis.del(...keys);
-        console.log(`Invalidadas ${keys.length} claves con patrón ${pattern}`);
-      }
-    } catch (error) {
-      console.error("Error invalidando patrón:", error);
     }
   }
 }


### PR DESCRIPTION
este es el dockerfile de frontend de pablo: 
# build stage
FROM node:8.15.0-alpine as build-stage
WORKDIR /app
COPY package*.json ./
RUN npm install
COPY . .
RUN npm run build

# production stage
FROM nginx:1.13.12-alpine as production-stage

# Install gettext for envsubst
RUN apk add --no-cache gettext

# Copy built application
COPY --from=build-stage /app/dist /usr/share/nginx/html

# Copy nginx template
COPY nginx.conf.template /etc/nginx/nginx.conf.template

# Create startup script directly in Dockerfile
RUN cat > /start.sh << 'EOF'
#!/bin/sh
set -e

# Replace environment variables in nginx.conf.template
envsubst '${AUTH_API_URL} ${TODOS_API_URL} ${USERS_API_URL} ${ZIPKIN_URL}' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf

# Create config.js with the API URLs for client-side access
cat > /usr/share/nginx/html/config.js << 'INNER_EOF'
window.CONFIG = {
  AUTH_API_URL: '${AUTH_API_URL}',
  TODOS_API_URL: '${TODOS_API_URL}',
  USERS_API_URL: '${USERS_API_URL}',
  ZIPKIN_URL: '${ZIPKIN_URL}'
};
INNER_EOF

# Start nginx
exec nginx -g 'daemon off;'
EOF
RUN sed -i 's/\r$//' /start.sh  && \  
        chmod +x /start.sh

EXPOSE 80
CMD ["/start.sh"]

------

Cambios realizados
Promisificación explícita de get, set, setex, del en cache-aside-service.js.
Serialización explícita JSON al escribir y validación centralizada (_isValidStructure).
Completar el patrón Cache-Aside: get() ahora guarda tras regenerar.
TTL = 0 para persistencia durable (combinado con Redis AOF existente).
Logging mejorado ([RAW key] ...) para depurar valor real en Redis.
Ajuste en creación de TODOs para actualizar correctamente lastInsertedID y mantener consistencia.
Frontend usa la respuesta del backend (si no estaba ya aplicado).

Resultado
Los TODOs creados persisten tras refrescar y reiniciar el contenedor [todos-api](vscode-file://vscode-app/c:/Users/Rafa/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
Redis almacena correctamente: {"items": {...}, "lastInsertedID": N}.
Eliminado el ciclo de “Invalid cached data structure… regenerating”.
Logs ahora reflejan lecturas válidas (Cache HIT + RAW JSON correcto).